### PR TITLE
Bump zigbee adapter to 0.3.1

### DIFF
--- a/list.json
+++ b/list.json
@@ -47,8 +47,8 @@
     "name": "zigbee-adapter",
     "display_name": "Zigbee",
     "description": "Zigbee device support",
-    "version": "0.3.0-pre2",
-    "url": "https://github.com/mozilla-iot/zigbee-adapter/releases/download/v0.3.0-pre2/zigbee-adapter-0.3.0-pre2.tgz",
+    "version": "0.3.1",
+    "url": "https://github.com/mozilla-iot/zigbee-adapter/releases/download/v0.3.1/zigbee-adapter-0.3.1.tgz",
     "api": {
       "min": 1,
       "max": 1


### PR DESCRIPTION
Tested on my RPi 3 using the 0.3.0 image.