### PR TITLE
Add netatmo weather station adapter

### DIFF
--- a/list.json
+++ b/list.json
@@ -178,6 +178,27 @@
     }
   },
   {
+    "name": "netatmo-weather-adapter",
+    "display_name": "Netatmo Weather Station",
+    "description": "Netatmo weather station support. Requires Netatmo Smart Home API credentials.",
+    "author": "Martin Giger",
+    "hhomepage": "https://github.com/freaktechnik/netatmo-weather-adapter",
+    "version": "0.1.0",
+    "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.0.tgz",
+    "checksum": "9cccb5d2103c00ff8f0dcd56176dc69edd3ebde59e65df1033546a089cfa53f7",
+    "packages": {
+      "any": {
+        "version": "0.1.0",
+        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.0.tgz",
+        "checksum": "9cccb5d2103c00ff8f0dcd56176dc69edd3ebde59e65df1033546a089cfa53f7"
+      }
+    },
+    "api": {
+      "min": 1,
+      "max": 2
+    }
+  },
+  {
     "name": "philips-hue-adapter",
     "display_name": "Philips Hue",
     "description": "Philips Hue color light support. Press the button on your Hue bridge to pair devices.",

--- a/list.json
+++ b/list.json
@@ -184,12 +184,12 @@
     "author": "Martin Giger",
     "homepage": "https://github.com/freaktechnik/netatmo-weather-adapter#readme",
     "version": "0.1.1",
-    "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.1/netatmo-weather-adapter-0.1.1.tgz",
+    "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/netatmo-weather-adapter-0.1.1.tgz",
     "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2",
     "packages": {
       "any": {
         "version": "0.1.1",
-        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.1/netatmo-weather-adapter-0.1.1.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/netatmo-weather-adapter-0.1.1.tgz",
         "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2"
       }
     },

--- a/list.json
+++ b/list.json
@@ -182,15 +182,15 @@
     "display_name": "Netatmo Weather Station",
     "description": "Netatmo weather station support. Requires Netatmo Smart Home API credentials.",
     "author": "Martin Giger",
-    "hhomepage": "https://github.com/freaktechnik/netatmo-weather-adapter",
-    "version": "0.1.0",
-    "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.0.tgz",
-    "checksum": "9cccb5d2103c00ff8f0dcd56176dc69edd3ebde59e65df1033546a089cfa53f7",
+    "homepage": "https://github.com/freaktechnik/netatmo-weather-adapter",
+    "version": "0.1.1",
+    "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.1/netatmo-weather-adapter-0.1.1.tgz",
+    "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2",
     "packages": {
       "any": {
-        "version": "0.1.0",
-        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.0.tgz",
-        "checksum": "9cccb5d2103c00ff8f0dcd56176dc69edd3ebde59e65df1033546a089cfa53f7"
+        "version": "0.1.1",
+        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.1.tgz",
+        "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2"
       }
     },
     "api": {

--- a/list.json
+++ b/list.json
@@ -189,7 +189,7 @@
     "packages": {
       "any": {
         "version": "0.1.1",
-        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.0/netatmo-weather-adapter-0.1.1.tgz",
+        "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.1/netatmo-weather-adapter-0.1.1.tgz",
         "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2"
       }
     },

--- a/list.json
+++ b/list.json
@@ -182,7 +182,7 @@
     "display_name": "Netatmo Weather Station",
     "description": "Netatmo weather station support. Requires Netatmo Smart Home API credentials.",
     "author": "Martin Giger",
-    "homepage": "https://github.com/freaktechnik/netatmo-weather-adapter",
+    "homepage": "https://github.com/freaktechnik/netatmo-weather-adapter#readme",
     "version": "0.1.1",
     "url": "https://github.com/freaktechnik/netatmo-weather-adapter/releases/download/v0.1.1/netatmo-weather-adapter-0.1.1.tgz",
     "checksum": "49a194cbd5d294cf68b881869fdd9852fec065b7124ace2303a905ff9ce4c9b2",


### PR DESCRIPTION
This is an interesting adapter:
it actually uses a REST API to a proprietary server (from the device manufacturer) to represent local devices. Further, in theory device properties are read-only, not that that's something that you can currently explicitly represent from what I can tell.