### PR TITLE
Add Switchmate adapter

### DIFF
--- a/list.json
+++ b/list.json
@@ -333,6 +333,24 @@
     }
   },
   {
+    "name": "switchmate-adapter",
+    "display_name": "Switchmate",
+    "description": "Switchmate switch support",
+    "author": "Brian Peiris",
+    "homepage": "https://github.com/brianpeiris/switchmate-adapter",
+    "packages": {
+      "linux-arm": {
+        "version": "0.1.0",
+        "url": "https://github.com/brianpeiris/switchmate-adapter/releases/download/v0.1.0/switchmate-adapter-0.1.0.tgz",
+        "checksum": "fdfd042b7aacf0ca5af16695a2a821f0a7c8cb1b217c899b9ee0841effbd85f8"
+      }
+    },
+    "api": {
+      "min": 1,
+      "max": 2
+    }
+  },
+  {
     "name": "thing-url-adapter",
     "display_name": "Web Thing",
     "description": "Native web thing support",


### PR DESCRIPTION
Adds support for [Switchmate](https://www.mysimplysmarthome.com/products/switchmate-switches/) devices. 
https://github.com/brianpeiris/switchmate-adapter

This could be blocked by https://github.com/mozilla-iot/gateway/issues/1280 since it still conflicts with `thing-url-adapter`.