### PR TITLE
DateTime 0.9.5

### DIFF
--- a/list.json
+++ b/list.json
@@ -92,7 +92,7 @@
           ]
         },
         "version": "0.9.5",
-        "url": "https://github.com/tomasy/date-time-adapter/releases/download/0.9.5/date-time-adapter-0.9.5.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/date-time-adapter-0.9.5.tgz",
         "checksum": "43cfeffe0673a3960d1ffbc6299e9f501b117960a162cdd1b832faf9180361b5",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -91,9 +91,9 @@
             "3.7"
           ]
         },
-        "version": "0.9.4",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/date-time-adapter-0.9.4.tgz",
-        "checksum": "36db0787457b617ae8d78ad7544f5ba5cb7595ac34a946ee60a23c7f9a6e740a",
+        "version": "0.9.5",
+        "url": "https://github.com/tomasy/date-time-adapter/releases/download/0.9.5/date-time-adapter-0.9.5.tgz",
+        "checksum": "43cfeffe0673a3960d1ffbc6299e9f501b117960a162cdd1b832faf9180361b5",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Added 2 new properties `Hour_N` and `Minute_N`. To create rules valid only between some time. See mozilla-iot/gateway#1475
It would be nice if it exist a link to a changelog file