### PR TITLE
Update activitypub-adapter to 0.0.9

### DIFF
--- a/list.json
+++ b/list.json
@@ -3,7 +3,7 @@
     "name": "activitypub-adapter",
     "display_name": "ActivityPub",
     "description": "Send notice to Mastodon SocialWeb. See: https://github.com/rzr/mastodon-lite",
-    "author": "Philippe Coval <p.coval@samsung.com> (https://www.npmjs.com/~rzr)",
+    "author": "Philippe Coval",
     "homepage": "https://github.com/rzr/mastodon-lite",
     "license": "https://github.com/rzr/mastodon-lite/blob/master/LICENSE",
     "packages": [

--- a/list.json
+++ b/list.json
@@ -16,7 +16,7 @@
           ]
         },
         "version": "0.0.9",
-        "url": "https://github.com/rzr/mastodon-lite/releases/download/v0.0.9/activitypub-adapter-0.0.9.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/activitypub-adapter-0.0.9.tgz",
         "checksum": "508e2694321d19a07f4884601b54a435488a94729ec482b1542bffd2b0f1b401",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -3,7 +3,7 @@
     "name": "activitypub-adapter",
     "display_name": "ActivityPub",
     "description": "Send notice to Mastodon SocialWeb. See: https://github.com/rzr/mastodon-lite",
-    "author": "Philippe Coval",
+    "author": "Philippe Coval <p.coval@samsung.com> (https://www.npmjs.com/~rzr)",
     "homepage": "https://github.com/rzr/mastodon-lite",
     "license": "https://github.com/rzr/mastodon-lite/blob/master/LICENSE",
     "packages": [
@@ -15,9 +15,9 @@
             "any"
           ]
         },
-        "version": "0.0.8",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/activitypub-adapter-0.0.8.tgz",
-        "checksum": "113f3c7808cf694b7192772ca6c3204dcc00d32f1694d8119e95c1975f5e1e3a",
+        "version": "0.0.9",
+        "url": "https://github.com/rzr/mastodon-lite/releases/download/v0.0.9/activitypub-adapter-0.0.9.tgz",
+        "checksum": "508e2694321d19a07f4884601b54a435488a94729ec482b1542bffd2b0f1b401",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Source: https://github.com/rzr/mastodon-lite/releases/tag/v0.0.9
Relate-to: https://github.com/mozilla-iot/addon-list/pull/158
Change-Id: I5e793046df49dd7d88e5733749bf6c3fbffce4d5
Signed-off-by: Philippe Coval <p.coval@samsung.com>