### PR TITLE
Add maxSMART 2.0 Adapter

### DIFF
--- a/list.json
+++ b/list.json
@@ -664,7 +664,7 @@
         },
         "version": "0.0.1",
         "url": "https://github.com/freaktechnik/maxsmart2-adapter/releases/download/v0.0.1/maxsmart2-adapter-0.0.1.tgz",
-        "checksum": "1612f825abdecdeb95ca8e0b7c679864a04092800a0890f49771c8bef22d4bfc",
+        "checksum": "5e221e108c33c6d5ddd49b0d6a4f41149e0ef72a072a674fa299c3d29de7b176",
         "api": {
           "min": 2,
           "max": 2

--- a/list.json
+++ b/list.json
@@ -647,6 +647,32 @@
     ]
   },
   {
+    "name": "maxsmart2-adapter",
+    "display_name": "MaxHauri maxSMART 2.0",
+    "description": "Control MAx Hauri maxSMART 2.0 smart plugs. Does not support automatic pairing.",
+    "author": "Martin Giger",
+    "homepage": "https://github.com/freaktechnik/maxsmart2-adapter#readme",
+    "license": "https://github.com/freaktechnik/maxsmart2-adapter/blob/master/LICENSE",
+    "packages": [
+      {
+        "architecture": "any",
+        "language": {
+          "name": "nodejs",
+          "versions": [
+            "any"
+          ]
+        },
+        "version": "0.0.1",
+        "url": "https://github.com/freaktechnik/maxsmart2-adapter/releases/download/v0.0.1/maxsmart2-adapter-0.0.1.tgz",
+        "checksum": "1612f825abdecdeb95ca8e0b7c679864a04092800a0890f49771c8bef22d4bfc",
+        "api": {
+          "min": 2,
+          "max": 2
+        }
+      }
+    ]
+  },
+  {
     "name": "microblocks-adapter",
     "display_name": "MicroBlocks",
     "description": "MicroBlocks board support",

--- a/list.json
+++ b/list.json
@@ -663,7 +663,7 @@
           ]
         },
         "version": "0.0.1",
-        "url": "https://github.com/freaktechnik/maxsmart2-adapter/releases/download/v0.0.1/maxsmart2-adapter-0.0.1.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/maxsmart2-adapter-0.0.1.tgz",
         "checksum": "5e221e108c33c6d5ddd49b0d6a4f41149e0ef72a072a674fa299c3d29de7b176",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -648,8 +648,8 @@
   },
   {
     "name": "maxsmart2-adapter",
-    "display_name": "MaxHauri maxSMART 2.0",
-    "description": "Control MAx Hauri maxSMART 2.0 smart plugs. Does not support automatic pairing.",
+    "display_name": "Max Hauri maxSMART 2.0",
+    "description": "Control Max Hauri maxSMART 2.0 smart plugs. Does not support automatic pairing.",
     "author": "Martin Giger",
     "homepage": "https://github.com/freaktechnik/maxsmart2-adapter#readme",
     "license": "https://github.com/freaktechnik/maxsmart2-adapter/blob/master/LICENSE",


### PR DESCRIPTION
This is an adapter for a pretty obscure smart plug that probably only exists in Switzerland in this form (due to Switzerland having its own plug system). It's likely though, that there are other plugs using a similar protocol, made originally by Revogi and possibly rebranded...