### PR TITLE
Update generic-sensors-adapter to 0.0.7

### DIFF
--- a/list.json
+++ b/list.json
@@ -254,9 +254,25 @@
             "57"
           ]
         },
-        "version": "0.0.6",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.6-linux-arm-v8.tgz",
-        "checksum": "6e90fe252f5cae8828d95a02ad57b017e9ced9dc6e139f6a39b14947cd1a3003",
+        "version": "0.0.7",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-arm-v8.tgz",
+        "checksum": "0ca2d6819270e27efc9a470979a10ea65377ef57c4207ad73f31d75ec242cf2f",
+        "api": {
+          "min": 2,
+          "max": 2
+        }
+      },
+      {
+        "architecture": "linux-arm64",
+        "language": {
+          "name": "nodejs",
+          "versions": [
+            "57"
+          ]
+        },
+        "version": "0.0.7",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-arm64-v8.tgz",
+        "checksum": "163891ab0d82805106cef9c23ee862a042ecd4498f269626acf19b012a5b1ca9",
         "api": {
           "min": 2,
           "max": 2
@@ -270,9 +286,9 @@
             "57"
           ]
         },
-        "version": "0.0.6",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.6-linux-ia32-v8.tgz",
-        "checksum": "bc0d686930d0bcf6dad47882bd49c871466afcf1f1d43d7afd0e86d9cf31853a",
+        "version": "0.0.7",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-ia32-v8.tgz",
+        "checksum": "9a04bd18f3b58f1391f576e9349a71ce4c77f1aaa4f42a551b444626e0f38bcf",
         "api": {
           "min": 2,
           "max": 2
@@ -286,9 +302,9 @@
             "57"
           ]
         },
-        "version": "0.0.6",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.6-linux-x64-v8.tgz",
-        "checksum": "8261b1eb97e6e0ba1ac4af255bb5e6ce6c4957715aa195383cffb530bde2aab1",
+        "version": "0.0.7",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-x64-v8.tgz",
+        "checksum": "3405f895af6e4290b38120171b57d8b6aebc5ad816110b32485300ece1542634",
         "api": {
           "min": 2,
           "max": 2

--- a/list.json
+++ b/list.json
@@ -255,7 +255,7 @@
           ]
         },
         "version": "0.0.7",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-arm-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.7-linux-arm-v8.tgz",
         "checksum": "0ca2d6819270e27efc9a470979a10ea65377ef57c4207ad73f31d75ec242cf2f",
         "api": {
           "min": 2,
@@ -271,7 +271,7 @@
           ]
         },
         "version": "0.0.7",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-arm64-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.7-linux-arm64-v8.tgz",
         "checksum": "163891ab0d82805106cef9c23ee862a042ecd4498f269626acf19b012a5b1ca9",
         "api": {
           "min": 2,
@@ -287,7 +287,7 @@
           ]
         },
         "version": "0.0.7",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-ia32-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.7-linux-ia32-v8.tgz",
         "checksum": "9a04bd18f3b58f1391f576e9349a71ce4c77f1aaa4f42a551b444626e0f38bcf",
         "api": {
           "min": 2,
@@ -303,7 +303,7 @@
           ]
         },
         "version": "0.0.7",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.7/generic-sensors-adapter-0.0.7-linux-x64-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.7-linux-x64-v8.tgz",
         "checksum": "3405f895af6e4290b38120171b57d8b6aebc5ad816110b32485300ece1542634",
         "api": {
           "min": 2,


### PR DESCRIPTION
Fixes id, then things can be propertly removed.

ARMv8 support added

Change-Id: I8bc80fb16d5c2b3145e111f0e0ce772b9b4fd798
Relate-to: https://github.com/mozilla-iot/addon-list/pull/206
Signed-off-by: Philippe Coval <p.coval@samsung.com>