### PR TITLE
MySensors to version 0.0.3

### DIFF
--- a/list.json
+++ b/list.json
@@ -1128,9 +1128,9 @@
             "3.7"
           ]
         },
-        "version": "0.0.2",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.0.2.tgz",
-        "checksum": "e6833a880e19e9ddfe169e54367f7c220bce71d0003370e470556dce67f35d80",
+        "version": "0.0.3",
+        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.0.3.tgz",
+        "checksum": "de07d58f3546d599623e818641eb6271166cb27f5e237395cc4bc042171fd1dd",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Fixes persistence. The add-on now remembers all the devices it has seen before. This fixes an edge-case issue where devices could be issued the same ID, and would then conflict.

I changes the URL to a github version, perhaps that should be changed back?

The MySensors persistence json is stored in the plugin directory. This is on purpose, so that once in a while it will be able to start again and forget old devices. If this is an issue I can change it to store the file in the config directory.