### PR TITLE
Upgrade to version 0.0.5

### DIFF
--- a/list.json
+++ b/list.json
@@ -1392,9 +1392,9 @@
             "3.7"
           ]
         },
-        "version": "0.0.4",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.0.4.tgz",
-        "checksum": "bc07b871231b9a0621811220e96d34f621fb8a3cbe90a72203bb088bdadc2d49",
+        "version": "0.0.5",
+        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.0.5.tgz",
+        "checksum": "8fd34cdfa8977d1800bcbed08db043e927672ac45d4b8dfb79c23c0afad0ac1e",
         "api": {
           "min": 2,
           "max": 2

--- a/list.json
+++ b/list.json
@@ -1393,7 +1393,7 @@
           ]
         },
         "version": "0.0.5",
-        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.0.5.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.0.5.tgz",
         "checksum": "8fd34cdfa8977d1800bcbed08db043e927672ac45d4b8dfb79c23c0afad0ac1e",
         "api": {
           "min": 2,


### PR DESCRIPTION
Getting closer to a 1.0 release.


- Expanded support for MySensors types
- More careful implementation of Mozilla's IoT schema capabilities
- Persistence as you would expect it: if enabled, all things are immediately re-created after a reboot of the gateway.
- Proper support for removing devices. They are cleared from the persistence as well.