### PR TITLE
MySensors to 0.0.7

### DIFF
--- a/list.json
+++ b/list.json
@@ -1447,7 +1447,7 @@
           ]
         },
         "version": "0.0.7",
-        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.0.7.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.0.7.tgz",
         "checksum": "b8946cbfd4dd8fcccdc821a51070d6b66e40565fcb1f07e17e73e686d591ebe0",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -1446,9 +1446,9 @@
             "3.7"
           ]
         },
-        "version": "0.0.6",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.0.6.tgz",
-        "checksum": "fb8dcfb6736be580733c007d1309bc40470269cc5d2cc649a999b15a931cb904",
+        "version": "0.0.7",
+        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.0.7.tgz",
+        "checksum": "b8946cbfd4dd8fcccdc821a51070d6b66e40565fcb1f07e17e73e686d591ebe0",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Fixes issue where preferred capability to display centrally was forgotten on add-on restart.
Also, the persistence feature has been replaced with an option to show a device as connected only after some signal has been received.