### PR TITLE
Update generic-sensors-adapter to v0.0.9

### DIFF
--- a/list.json
+++ b/list.json
@@ -486,7 +486,7 @@
           ]
         },
         "version": "0.0.9",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-arm-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.9-linux-arm-v8.tgz",
         "checksum": "9447fae66139249d2c00e551d748d7a01e1f86cfefc406f7d4fa6ae460ab01d9",
         "api": {
           "min": 2,
@@ -502,7 +502,7 @@
           ]
         },
         "version": "0.0.9",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-arm64-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.9-linux-arm64-v8.tgz",
         "checksum": "32bf0f54ccbc6533fd0c3b8e4fb950468194a1e25601109ac4461c3f72976845",
         "api": {
           "min": 2,
@@ -518,7 +518,7 @@
           ]
         },
         "version": "0.0.9",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-ia32-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.9-linux-ia32-v8.tgz",
         "checksum": "cc3811cefbd65082b3277970ae3339b8df833c39b82a0ab98cb96a852c8be8e9",
         "api": {
           "min": 2,
@@ -534,7 +534,7 @@
           ]
         },
         "version": "0.0.9",
-        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-x64-v8.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.9-linux-x64-v8.tgz",
         "checksum": "d8eea39767395241f860c5760b759fd68df0e667853037c19ee119347fc6ac4e",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -485,9 +485,9 @@
             "57"
           ]
         },
-        "version": "0.0.8",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.8-linux-arm-v8.tgz",
-        "checksum": "eff7a7f505ad25975d23c03edb5223aaefbc944237d00efe276f1fc9589169c4",
+        "version": "0.0.9",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-arm-v8.tgz",
+        "checksum": "9447fae66139249d2c00e551d748d7a01e1f86cfefc406f7d4fa6ae460ab01d9",
         "api": {
           "min": 2,
           "max": 2
@@ -501,9 +501,9 @@
             "57"
           ]
         },
-        "version": "0.0.8",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.8-linux-arm64-v8.tgz",
-        "checksum": "4b9921852c2b434633f5377a33abfc6212c301c298408b5336a3452a15fa6da4",
+        "version": "0.0.9",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-arm64-v8.tgz",
+        "checksum": "32bf0f54ccbc6533fd0c3b8e4fb950468194a1e25601109ac4461c3f72976845",
         "api": {
           "min": 2,
           "max": 2
@@ -517,9 +517,9 @@
             "57"
           ]
         },
-        "version": "0.0.8",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.8-linux-ia32-v8.tgz",
-        "checksum": "f750c5792b9088c172185c20514d8886ae703ba12a2fcfa37a96aaece999a100",
+        "version": "0.0.9",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-ia32-v8.tgz",
+        "checksum": "cc3811cefbd65082b3277970ae3339b8df833c39b82a0ab98cb96a852c8be8e9",
         "api": {
           "min": 2,
           "max": 2
@@ -533,9 +533,9 @@
             "57"
           ]
         },
-        "version": "0.0.8",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/generic-sensors-adapter-0.0.8-linux-x64-v8.tgz",
-        "checksum": "cf1fb18be0005977230aa6953af54af21273be785b14b1a6a0516bdd3d5a14a7",
+        "version": "0.0.9",
+        "url": "https://github.com/rzr/mozilla-iot-generic-sensors-adapter/releases/download/v0.0.9/generic-sensors-adapter-0.0.9-linux-x64-v8.tgz",
+        "checksum": "d8eea39767395241f860c5760b759fd68df0e667853037c19ee119347fc6ac4e",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Fixing logging features, simplified config

Test with simulators:

https://hub.samsunginter.net/adding-sensors-to-the-web-of-things/

Relate-to: https://github.com/mozilla-iot/addon-list/pull/54
Change-Id: Ib917be0a948036530fb5ed947ab1139899309cc3
Signed-off-by: Philippe Coval <p.coval@samsung.com>