### PR TITLE
Update activitypub adapter to 0.0.14

### DIFF
--- a/list.json
+++ b/list.json
@@ -17,7 +17,7 @@
           ]
         },
         "version": "0.0.14",
-        "url": "https://github.com/rzr/mastodon-lite/releases/download/v0.0.14/activitypub-adapter-0.0.14.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/activitypub-adapter-0.0.14.tgz",
         "checksum": "e0764505cc9839db3b81c55b8312437e4c0fa2fc0588f6f372af5649d478b0af",
         "api": {
           "min": 2,

--- a/list.json
+++ b/list.json
@@ -16,9 +16,9 @@
             "any"
           ]
         },
-        "version": "0.0.10",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/activitypub-adapter-0.0.10.tgz",
-        "checksum": "58cb62bb1c267efc81b2d4089395dc3a380c9eb72682f9726d9dc085345a3561",
+        "version": "0.0.14",
+        "url": "https://github.com/rzr/mastodon-lite/releases/download/v0.0.14/activitypub-adapter-0.0.14.tgz",
+        "checksum": "e0764505cc9839db3b81c55b8312437e4c0fa2fc0588f6f372af5649d478b0af",
         "api": {
           "min": 2,
           "max": 2


### PR DESCRIPTION
Change-Id: Ifc7bfe0a46495cfd06fa2bb707bb1f55ea60ed82
Relate-to: https://github.com/mozilla-iot/addon-list/pull/158
Signed-off-by: Philippe Coval <p.coval@samsung.com>