### PR TITLE
Candle manager 0.0.6

### DIFF
--- a/list.json
+++ b/list.json
@@ -126,9 +126,9 @@
             "3.7"
           ]
         },
-        "version": "0.0.5",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-0.0.5.tgz",
-        "checksum": "f8e71ab93bfce8fb6e5a517b81cacc08516e9f78aa4b0465f039ef0661be23b0",
+        "version": "0.0.6",
+        "url": "https://github.com/createcandle/Candle-manager-addon/raw/master/Candle-manager-0.0.6.tgz",
+        "checksum": "67261e5493b212ad5acc8890d42d9f794ac25352eee0e0b89f082a3bd6900ca7",
         "api": {
           "min": 2,
           "max": 2

--- a/list.json
+++ b/list.json
@@ -127,7 +127,7 @@
           ]
         },
         "version": "0.0.6",
-        "url": "https://github.com/createcandle/Candle-manager-addon/raw/master/Candle-manager-0.0.6.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-0.0.6.tgz",
         "checksum": "67261e5493b212ad5acc8890d42d9f794ac25352eee0e0b89f082a3bd6900ca7",
         "api": {
           "min": 2,


### PR DESCRIPTION
Adds Title support.
Various other improvements, mostly for the 'advanced' option.
Fixes edge case where a double click could start two simultaneous processes, resulting in errors.