### PR TITLE
MySensors version 0.1.2

### DIFF
--- a/list.json
+++ b/list.json
@@ -1708,9 +1708,9 @@
             "3.7"
           ]
         },
-        "version": "0.1.0",
-        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.1.0.tgz",
-        "checksum": "40fcb9b96c5abcfa5ae6e77eeb19d339780a1d708efd2dc03df6f2e6cfd39a82",
+        "version": "0.1.2",
+        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.1.2.tgz",
+        "checksum": "09614f854200c1665ed7dba287203cb885fbc5bd266dadf39ea537c417665947",
         "api": {
           "min": 2,
           "max": 2

--- a/list.json
+++ b/list.json
@@ -1709,7 +1709,7 @@
           ]
         },
         "version": "0.1.2",
-        "url": "https://github.com/createcandle/Webthings-mysensors-adapter/raw/master/mysensors-adapter-0.1.2.tgz",
+        "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-0.1.2.tgz",
         "checksum": "09614f854200c1665ed7dba287203cb885fbc5bd266dadf39ea537c417665947",
         "api": {
           "min": 2,


### PR DESCRIPTION
- Automatic serial port searching. User doesn't need to add a serial port ID manually anymore (but can if they want)
- Support for metric/imperial units. You can set your preference in the add-on settings.
- Support for multipleOf. This should help show a sane amount of decimals on numeric variables.
- Experimental MQTT support based on user feedback
- Anticipates switch to version 0.9 of the WebThings gateway by implementing title support.