### PR TITLE
Update Mi Flora adapter to 0.2.3

### DIFF
--- a/addons/mi-flora-adapter.json
+++ b/addons/mi-flora-adapter.json
@@ -17,7 +17,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-linux-arm-v8.tgz",
-      "checksum": "",
+      "checksum": "1298bb2168170238465d6a935ae4874eb31663475b8714645520202745ac224e",
       "api": {
         "min": 2,
         "max": 2
@@ -37,7 +37,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-linux-x64-v8.tgz",
-      "checksum": "",
+      "checksum": "5bd8440181165763d33e808ee12eadb5c8cf4e858d0094a2d85f55ea06117045",
       "api": {
         "min": 2,
         "max": 2
@@ -57,7 +57,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-darwin-x64-v8.tgz",
-      "checksum": "",
+      "checksum": "c61b46389104f6eb3801ecbdd51c317dda2d9585c52c74ca81809764e7e7553f",
       "api": {
         "min": 2,
         "max": 2
@@ -77,7 +77,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-linux-arm-v10.tgz",
-      "checksum": "",
+      "checksum": "d5aaf43946bf1acb6a9192eeaec4c4a179f4f550c5841189c02bcc218d61ad3d",
       "api": {
         "min": 2,
         "max": 2
@@ -97,7 +97,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-linux-x64-v10.tgz",
-      "checksum": "",
+      "checksum": "17be174de243e60771c7404781b41ac726ce631acb656de8ab2ef99de3db455b",
       "api": {
         "min": 2,
         "max": 2
@@ -117,7 +117,7 @@
       },
       "version": "0.2.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mi-flora-adapter-0.2.3-darwin-x64-v10.tgz",
-      "checksum": "",
+      "checksum": "bcc0a41929325df5812ebb2f46403f6329f227303dff7c7a594499b96779e1fd",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
Addon builder needs to be run, and the checksums need to be set.

tim-hellhake/mi-flora-adapter#8