### PR TITLE
Fixes the package-to-manifest.py script

### DIFF
--- a/tools/package-to-manifest.py
+++ b/tools/package-to-manifest.py
@@ -37,7 +37,7 @@ def translate(package_json):
     if type(package['author']) is str:
         manifest['author'] = package['author']
     else:
-        manifest['author'] = package['author']['name']
+        manifest['author'] = str(package['author'])
 
     if 'type' in package['moziot']:
         manifest['gateway_specific_settings']['webthings']['primary_type'] = \


### PR DESCRIPTION
The `package.json` does not have`name` as a key to `author`.