### PR TITLE
Voco 0.1.0

### DIFF
--- a/addons/voco.json
+++ b/addons/voco.json
@@ -17,9 +17,9 @@
           "3.7"
         ]
       },
-      "version": "0.0.9",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/voco-0.0.9.tgz",
-      "checksum": "721b6075ef69bab6a79709e22a08c4909660dd9cc1046352d3d5107224cb56b3",
+      "version": "0.1.0",
+      "url": "https://www.candlesmarthome.com/assistant/voco-0.1.0.tgz",
+      "checksum": "a0231e52abf672f747fa2cfa6c5ed28c4645f08f85101a09ffd8fc1f8a4f9824",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
- Fixed issue where Snips assistant would interpret 'moisture' as 'humidity'. The add-on now works well with the MiFlora add-on.
- Fixed issue where asking "turn on [device name] in 5 minutes" gave a "that time is in the past" error.