### PR TITLE
Candle manager version 1.0.0

### DIFF
--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -17,9 +17,9 @@
           "3.7"
         ]
       },
-      "version": "0.0.10",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-0.0.10.tgz",
-      "checksum": "d44543e707db7e32b6e1cfea8ef267b48bdafb8fdbf082751a7dbe59222b29d6",
+      "version": "1.0.0",
+      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.0/Candle-manager-addon-1.0.0.tgz",
+      "checksum": "5b20940b38fb5fe3815df578d1fe7f377de87d4ab160ff6fe6f0528e1844b873",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -18,7 +18,7 @@
         ]
       },
       "version": "1.0.0",
-      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.0/Candle-manager-addon-1.0.0.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.0.tgz",
       "checksum": "5b20940b38fb5fe3815df578d1fe7f377de87d4ab160ff6fe6f0528e1844b873",
       "api": {
         "min": 2,


### PR DESCRIPTION
- better handling of gateway 0.10.0 code on older versions of the gateway
- gateway.local link in thing is no longer hardcoded, but reflects actual LAN ip address.