### PR TITLE
First release of Power Settings

### DIFF
--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -5,7 +5,7 @@
   "author": "Flatsiedatsie",
   "homepage_url": "https://github.com/flatsiedatsie/power-settings",
   "license_url": "https://github.com/flatsiedatsie/power-settings/blob/master/LICENSE",
-  "primary_type": "adapter",
+  "primary_type": "extension",
   "packages": [
     {
       "architecture": "linux-arm",

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "a2dd03ab56a006e36dff21412a9cae0d08c1ad789296c42f98b41c9c4380a4ba",
+      "checksum": "b647119f57662d48df9967d7af6af942cbf0467aeb16c1f4ade1c3c3b7c00c8a",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "260c2149d26aec8106975bc0acbc188d7e43e03a42dd4d9ea825c665fa087253",
+      "checksum": "13187aa32b04becc2981bb14bdf0af2288b1fd72a8f5bdc97a39d759fc933f98",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "13187aa32b04becc2981bb14bdf0af2288b1fd72a8f5bdc97a39d759fc933f98",
+      "checksum": "637c81cc3e99f5575bf8db9f3cc8a13eccfe5aab43d9b8bed8163fa967bc2887",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "be35f6fa3d01a3dd3d997a7a7ca0905403596f9d5c5a468aa16678304e2ad705",
+      "checksum": "a2dd03ab56a006e36dff21412a9cae0d08c1ad789296c42f98b41c9c4380a4ba",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -18,7 +18,7 @@
         ]
       },
       "version": "0.0.1",
-      "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/power-settings-0.0.1.tgz",
       "checksum": "f1670f3a3f985d3f9b22377c8f24cad884d0da974185536e7e0e894d0e5b228a",
       "api": {
         "min": 2,

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "97266ec0b554794dd6aa4e423c232948824c231e75606322dcbd08b05911bfc0",
+      "checksum": "0426fbac6b6ca26393ed7f4474d8413e5ff010dac6a457a31d306db523d0c0ee",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "0426fbac6b6ca26393ed7f4474d8413e5ff010dac6a457a31d306db523d0c0ee",
+      "checksum": "260c2149d26aec8106975bc0acbc188d7e43e03a42dd4d9ea825c665fa087253",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "2518d22ce2c07996a5e573c0e3703d940a94c6bb107ee7eeb19e8ad032456a49",
+      "checksum": "77863c369359d077389ee65432875c834baa2e9520114817b4b684a9f0268d06",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "16062c4c90dbf4c377c3f2155f5ba1bcd10cac0771b9f3a786887d2afed7f82d",
+      "checksum": "be35f6fa3d01a3dd3d997a7a7ca0905403596f9d5c5a468aa16678304e2ad705",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "637c81cc3e99f5575bf8db9f3cc8a13eccfe5aab43d9b8bed8163fa967bc2887",
+      "checksum": "2518d22ce2c07996a5e573c0e3703d940a94c6bb107ee7eeb19e8ad032456a49",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -1,6 +1,6 @@
 {
   "id": "power-settings",
-  "name": "Power settings",
+  "name": "Power Settings",
   "description": "Shutdown or reboot your system, go fullscreen, and manually set the time.",
   "author": "Flatsiedatsie",
   "homepage_url": "https://github.com/flatsiedatsie/power-settings",

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "77863c369359d077389ee65432875c834baa2e9520114817b4b684a9f0268d06",
+      "checksum": "496baf7127f99e0e4bff119e90c4b75a2c4d2758ab876011363b09892c985182",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "d41f061eaeaa9c423f177d4a94ca6173b411d3b45d5cab4392fe86b9f48267be",
+      "checksum": "16062c4c90dbf4c377c3f2155f5ba1bcd10cac0771b9f3a786887d2afed7f82d",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "288ad6595bff2e19ce6a9ab3c21a22c7ca94c5ad4365ee72f9f42a041ca15aaf",
+      "checksum": "f1670f3a3f985d3f9b22377c8f24cad884d0da974185536e7e0e894d0e5b228a",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "58ec78f28ef22a9258c00d5e41be81ee77a105585ed73e1c15357aa76dc30252",
+      "checksum": "97266ec0b554794dd6aa4e423c232948824c231e75606322dcbd08b05911bfc0",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -1,0 +1,33 @@
+{
+  "id": "power-settings",
+  "name": "Power settings",
+  "description": "Shutdown or reboot your system, go fullscreen, and manually set the time.",
+  "author": "Flatsiedatsie",
+  "homepage_url": "https://github.com/flatsiedatsie/power-settings",
+  "license_url": "https://github.com/flatsiedatsie/power-settings/blob/master/LICENSE",
+  "primary_type": "adapter",
+  "packages": [
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
+      "checksum": "d41f061eaeaa9c423f177d4a94ca6173b411d3b45d5cab4392fe86b9f48267be",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "b647119f57662d48df9967d7af6af942cbf0467aeb16c1f4ade1c3c3b7c00c8a",
+      "checksum": "58ec78f28ef22a9258c00d5e41be81ee77a105585ed73e1c15357aa76dc30252",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/power-settings.json
+++ b/addons/power-settings.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/power-settings/releases/download/0.0.1/power-settings-0.0.1.tgz",
-      "checksum": "496baf7127f99e0e4bff119e90c4b75a2c4d2758ab876011363b09892c985182",
+      "checksum": "288ad6595bff2e19ce6a9ab3c21a22c7ca94c5ad4365ee72f9f42a041ca15aaf",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
A pun on its ability to shutdown and restart your system, although more options were soon added. Making one add-on makes it easier to maintain.

It has no requirements.

FEATURES
- Shutdown your system
- Reboot your system
- Toggle fullscreen mode (pure javascript)
- Manually set the correct time

The last feature currently has an ability that warrent discussion. It can toggle whether the NTP daemon may use external servers to get the time. This is not a permanent setting (reboot and it's gone), it can only temporarily override this. It's fully optional.

I don't believe it hampers any of the other add-ons, since it's not like there will not be a time available. It also doesn't install anything new. It's just that by installing the add-on the user gains the ability to set the time manually. This has a few use cases.

A. Set the actual time
- Sometimes a user may want to override the time when the system is not providing the correct time. As long as NTP is allowed to update the time, users cannot set the time manually (except perhaps by fiddling with the timezone).

One example of this is when the system reboots when there is no internet connection available. I've been in this situation a lot. Exhibits, smart caravans that are not connected to the internet, etc.

B. Enhance privacy
- If a user disables the connection with NTP servers, privacy is enhanced. Currently, the NTP connection is one of the areas where there is little control over where the user's IP address gets set. While NTP is active, the user's system continuously emits requests for the current time, effectively sharing personal data (IP address) as well as behavioural data with unknown third parties. This add-on allows the WebThings Gateway to truly operate 'cloudlessly'.