### PR TITLE
A new Xiaomi MiFlora adapter

### DIFF
--- a/addons/xiaomi-miflora.json
+++ b/addons/xiaomi-miflora.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/xiaomi-miflora/releases/download/0.0.1/xiaomi-miflora-0.0.1.tgz",
-      "checksum": "76ac8525d5e4c3f1746d5202ce90d2b930da2607ada2cdf894ee87400ec5213e",
+      "checksum": "9b7a375409b503bb4e255bea770c55cd60f4500442ab759f098c11a55ecddc1f",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/xiaomi-miflora.json
+++ b/addons/xiaomi-miflora.json
@@ -1,0 +1,33 @@
+{
+  "id": "xiaomi-miflora",
+  "name": "Xiaomi MiFlora",
+  "description": "Support for MiFlora flower care devices by Xiaomi",
+  "author": "Flatsiedatsie",
+  "homepage_url": "https://github.com/flatsiedatsie/xiaomi-miflora",
+  "license_url": "https://github.com/flatsiedatsie/xiaomi-miflora/blob/master/LICENSE",
+  "primary_type": "adapter",
+  "packages": [
+    {
+      "architecture": "any",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://github.com/flatsiedatsie/xiaomi-miflora/releases/download/0.0.1/xiaomi-miflora-0.0.1.tgz",
+      "checksum": "76ac8525d5e4c3f1746d5202ce90d2b930da2607ada2cdf894ee87400ec5213e",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/xiaomi-miflora.json
+++ b/addons/xiaomi-miflora.json
@@ -19,7 +19,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/xiaomi-miflora/releases/download/0.0.1/xiaomi-miflora-0.0.1.tgz",
-      "checksum": "9b7a375409b503bb4e255bea770c55cd60f4500442ab759f098c11a55ecddc1f",
+      "checksum": "6ddcc6b201d0c58c0b0803e5987ed2a036893f268a3490b69377a2d0151a46f5",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
Why another MiFlora adapter?
- The existing adapter [doesn't work with all my versions of the Flower Mate](https://github.com/tim-hellhake/mi-flora-adapter/issues/8). This one does (for now..).
- It only updates values that it actually receives, avoiding setting the entire device to zero/disconnected.
- If a connection fails, it will retry once.