### PR TITLE
Network presence detector 0.1.1

### DIFF
--- a/addons/network-presence-detection-adapter.json
+++ b/addons/network-presence-detection-adapter.json
@@ -20,7 +20,7 @@
       },
       "version": "0.1.1",
       "url": "https://github.com/flatsiedatsie/webthings-network-presence-detection/releases/download/0.1.1/network-presence-detection-adapter-0.1.1.tgz",
-      "checksum": "40cc4495e5c27227bbdf4e2098c5e5f618a4fce3372976fd5c5428666cdd3963",
+      "checksum": "8828e949f2f6fa0996009f0b313096e3b9a61191d39e28e889d2f8d2cbf7ce06",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/network-presence-detection-adapter.json
+++ b/addons/network-presence-detection-adapter.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "0.1.0",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/network-presence-detection-adapter-0.1.0.tgz",
-      "checksum": "2e903cac5177455e8f6bb873de0fab37a9cf06748e2004f561410dad90c6c6aa",
+      "version": "0.1.1",
+      "url": "https://github.com/flatsiedatsie/webthings-network-presence-detection/releases/download/0.1.1/network-presence-detection-adapter-0.1.1.tgz",
+      "checksum": "40cc4495e5c27227bbdf4e2098c5e5f618a4fce3372976fd5c5428666cdd3963",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/network-presence-detection-adapter.json
+++ b/addons/network-presence-detection-adapter.json
@@ -19,7 +19,7 @@
         ]
       },
       "version": "0.1.1",
-      "url": "https://github.com/flatsiedatsie/webthings-network-presence-detection/releases/download/0.1.1/network-presence-detection-adapter-0.1.1.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/network-presence-detection-adapter-0.1.1.tgz",
       "checksum": "8828e949f2f6fa0996009f0b313096e3b9a61191d39e28e889d2f8d2cbf7ce06",
       "api": {
         "min": 2,


### PR DESCRIPTION
- To make the add-on more universal, this version moves use or `arping` behind try commands, and tries`ping` first.
- Re-adds a 5 second sleep between the continuous scans.
- Moves almost all print statements behind debug toggle.
- Tries to get the device's name from `nmblookup` where possible.
- Overall code improvement.