### PR TITLE
tools: Support authors names as unicode

### DIFF
--- a/tools/package-to-manifest.py
+++ b/tools/package-to-manifest.py
@@ -34,7 +34,7 @@ def translate(package_json):
         'version': package['version'],
     }
 
-    if type(package['author']) is str:
+    if type(package['author']) is str or unicode:
         manifest['author'] = package['author']
     else:
         manifest['author'] = package['author']['name']


### PR DESCRIPTION
For some reasons it didnt parse ASCII characters as "str":

https://github.com/rzr/mastodon-lite/blob/master/example/mozilla-iot-activitypub-adapter/package.json

Change-Id: I3573dbb7d54f9137061dfaf0ad30db44b3524265
Signed-off-by: Philippe Coval <rzr@users.sf.net>