### PR TITLE
Candle manager 1.0.5

### DIFF
--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "1.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.4.tgz",
-      "checksum": "275d9ebe13c56578fd151fac3ced362fb7bc0d01fce5e6bcd0e76427379048f8",
+      "version": "1.0.5",
+      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.5/Candle-manager-addon-1.0.5.tgz",
+      "checksum": "8605fc1871ca2f6ad5c87aff737c2c91eb6dfb9c16b54601f3d5f2863cb5fd6a",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -19,7 +19,7 @@
         ]
       },
       "version": "1.0.5",
-      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.5/Candle-manager-addon-1.0.5.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.5.tgz",
       "checksum": "8605fc1871ca2f6ad5c87aff737c2c91eb6dfb9c16b54601f3d5f2863cb5fd6a",
       "api": {
         "min": 2,


### PR DESCRIPTION
Small fix for users who enabled the tunneling feature / https. Before it tried to load the candle manager as http.