### PR TITLE
MySensors 1.0.5 - fix handling of None values

### DIFF
--- a/addons/mysensors-adapter.json
+++ b/addons/mysensors-adapter.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "1.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-1.0.3.tgz",
-      "checksum": "da846fbf25e43c9a98e61025ac6747e9926c47360001d4e2a17e5651c7682afb",
+      "version": "1.0.5",
+      "url": "https://github.com/createcandle/Webthings-mysensors-adapter/releases/download/1.0.5/mysensors-adapter-1.0.5.tgz",
+      "checksum": "c672a517f88afefc0841ad18442d40614380b264b50f8fdaeafe280c7f3da8dc",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/mysensors-adapter.json
+++ b/addons/mysensors-adapter.json
@@ -19,7 +19,7 @@
         ]
       },
       "version": "1.0.5",
-      "url": "https://github.com/createcandle/Webthings-mysensors-adapter/releases/download/1.0.5/mysensors-adapter-1.0.5.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/mysensors-adapter-1.0.5.tgz",
       "checksum": "c672a517f88afefc0841ad18442d40614380b264b50f8fdaeafe280c7f3da8dc",
       "api": {
         "min": 2,


### PR DESCRIPTION
A bug was causing the recreation of devices from persistence to fail.