### PR TITLE
Candle manager 1.0.7

### DIFF
--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "1.0.6",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.6.tgz",
-      "checksum": "245f99e4f0d97daffa2db799a32e6ff3ef6ceac50d84cf51f1db8a41535ca9da",
+      "version": "1.0.7",
+      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.7/Candle-manager-addon-1.0.7.tgz",
+      "checksum": "fd27313e55b5aae04c42584ceb40cd8372eb01c1b1e87f42e73c52282c697569",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -29,6 +29,29 @@
         "min": "0.10.0",
         "max": "*"
       }
+    },
+    {
+      "architecture": "darwin-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7",
+          "3.8"
+        ]
+      },
+      "version": "1.0.7",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.7.tgz",
+      "checksum": "fd27313e55b5aae04c42584ceb40cd8372eb01c1b1e87f42e73c52282c697569",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
     }
   ]
 }

--- a/addons/Candle-manager-addon.json
+++ b/addons/Candle-manager-addon.json
@@ -19,7 +19,7 @@
         ]
       },
       "version": "1.0.7",
-      "url": "https://github.com/createcandle/Candle-manager-addon/releases/download/1.0.7/Candle-manager-addon-1.0.7.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/Candle-manager-addon-1.0.7.tgz",
       "checksum": "fd27313e55b5aae04c42584ceb40cd8372eb01c1b1e87f42e73c52282c697569",
       "api": {
         "min": 2,


### PR DESCRIPTION
- Can now handle empty #define strings
- Update of Arduino CLI to latest version
- Faster boot by moving init into a thread
- Fixed advanced options not showing up
- Fixed edge case where the list of sketches was multiplied