### PR TITLE
sense-hat: Update to 0.0.5 from 0.0.4

### DIFF
--- a/addons/sense-hat-adapter.json
+++ b/addons/sense-hat-adapter.json
@@ -12,12 +12,60 @@
       "language": {
         "name": "python",
         "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/sense-hat-adapter-0.0.5-linux-arm-v3.5.tgz",
+      "checksum": "ba7f87fed79b328938a8e18c915f7e3e69a71e266a810af883380861c73351c0",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/sense-hat-adapter-0.0.5-linux-arm-v3.6.tgz",
+      "checksum": "f4ac7b9f1457a9cae023c5d0e92f56a2aa394a8d82bf41813898547f19e00a87",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
           "3.7"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/sense-hat-adapter-0.0.4-linux-arm.tgz",
-      "checksum": "e1ebbe603b50f2f9befa250e7d09ff024e5b1c8c7de0446fb25f46ce5dc3f751",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/sense-hat-adapter-0.0.5-linux-arm-v3.7.tgz",
+      "checksum": "4a6ac25d5fb15b0e708ab45f6ea5d06587093fdf34a5018779a06e6e23fb9749",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/sense-hat-adapter-0.0.5-linux-arm-v3.8.tgz",
+      "checksum": "bfea94bb0644c044b9ab9dcdcc81575d5730b2b0b13066c5a8c41e8dcf00f634",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
URL is expected one once published by mozilla-iot

While checksum is the one from upstream's release file
but could differ if rebuilt using addon-builder.

Bug: https://github.com/rzr/sense-hat-webthing/issues/3
Relate-to: https://github.com/rzr/sense-hat-webthing/releases/tag/v0.0.5
Relate-to: https://github.com/rzr/sense-hat-webthing/releases/download/v0.0.5/sense-hat-adapter-0.0.5-linux-arm.tgz
Signed-off-by: Philippe Coval <rzr@users.sf.net>