### PR TITLE
awox-mesh-light-adapter: Add new adapter

### DIFF
--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -15,8 +15,8 @@
           "3.5"
         ]
       },
-      "version": "0.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.5.tgz",
+      "version": "0.0.3",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.5.tgz",
       "checksum": "",
       "gateway": {
         "min": "0.12.0",
@@ -31,8 +31,8 @@
           "3.6"
         ]
       },
-      "version": "0.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.6.tgz",
+      "version": "0.0.3",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.6.tgz",
       "checksum": "",
       "gateway": {
         "min": "0.12.0",
@@ -47,8 +47,8 @@
           "3.7"
         ]
       },
-      "version": "0.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.7.tgz",
+      "version": "0.0.3",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.7.tgz",
       "checksum": "",
       "gateway": {
         "min": "0.12.0",
@@ -63,8 +63,8 @@
           "3.8"
         ]
       },
-      "version": "0.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.8.tgz",
+      "version": "0.0.3",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.8.tgz",
       "checksum": "",
       "api": {
         "min": 2,

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -17,7 +17,7 @@
       },
       "version": "0.0.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.5.tgz",
-      "checksum": "",
+      "checksum": "4774451f12f78e8d0668ad5dcefb742160ccda19a30e68ca56168cea3b7c4f08",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -33,7 +33,7 @@
       },
       "version": "0.0.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.6.tgz",
-      "checksum": "",
+      "checksum": "d5869d1109fc08522fc110cba0eac3930c70b6dbe246753de086459ee2c62e8d",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -49,7 +49,7 @@
       },
       "version": "0.0.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.7.tgz",
-      "checksum": "",
+      "checksum": "d8e1ebcf4ce3999ac6fb7de50ce6f6fc4b64e328817ad423511bd1e69f710136",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -65,7 +65,7 @@
       },
       "version": "0.0.3",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.8.tgz",
-      "checksum": "",
+      "checksum": "a9944c2fb865d3bb05e3490b9aab23bbf9c319ebc6e38c8b64095f9978ee06f0",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -1,0 +1,79 @@
+{
+  "id": "awox-mesh-light-adapter",
+  "name": "AwoxMeshLight",
+  "description": "Awox mesh light device support",
+  "author": "Philippe Coval",
+  "homepage_url": "https://github.com/rzr/awox-mesh-light-webthing",
+  "license_url": "https://github.com/rzr/awox-mesh-light-webthing/blob/master/LICENSE",
+  "primary_type": "adapter",
+  "packages": [
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.2",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.5.tgz",
+      "checksum": "",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.2",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.6.tgz",
+      "checksum": "",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.2",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.7.tgz",
+      "checksum": "",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.2",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.2-linux-arm-v3.8.tgz",
+      "checksum": "",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -17,7 +17,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.5.tgz",
-      "checksum": "074e3dbd3a3b2ab3def8bdb449efb7f28d5902d2e7b0e6c658ecad9da5beea89",
+      "checksum": "48c445a2926d47ec3377cb79d63f7d5b82ec86bc7e687a619f5751d5b6205a18",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -33,7 +33,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.6.tgz",
-      "checksum": "ed2f29d6ce75cc6e9e7d7c51bdfd4a948e47078b13abf16f401c490285d52265",
+      "checksum": "4e71cc56dcfd1743b1ba58a025c13c464860d059955c96ed3b3adfc2c8191f29",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -49,7 +49,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.7.tgz",
-      "checksum": "35a925be2a9a96ddeeda2f96ea2198361f0fa0ef02e94227731732ae12c905c9",
+      "checksum": "f5992e52225db5e3c247284ab01ddf5b5057bae4ff956406b38c357c5082f01b",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -65,7 +65,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.8.tgz",
-      "checksum": "d5a866bb56c76092d648ebaa484fc664fcbfeae78d6ee5d586c340d5017611ff",
+      "checksum": "7e77447facde9d74eba734dac3021de3f8fe25fd9219c27b9425330b60bc48b4",
       "api": {
         "min": 2,
         "max": 2
@@ -85,7 +85,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.5.tgz",
-      "checksum": "494e37c3f19619c01b9a4792212230aea1efb6530136aded1f049771111e5cc6",
+      "checksum": "fc23a3b251c2e8aba76c4af406bca5aeac0ca457bc8b15a33b47f4283029f652",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -101,7 +101,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.6.tgz",
-      "checksum": "cdb0dd6867cafc9ddc5f3f34c1ed99f7a8facb6fea7a4793a681bbb3b3d58b9a",
+      "checksum": "bde0fa3b9722717c0376b66a8b0cb06df3ef699529eefeb868ee9d7d15ff0215",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -117,7 +117,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.7.tgz",
-      "checksum": "5d1a386fda1525f87fbd4a92b4414bd775e8bee589109c4a250ee00ce4ea4a4e",
+      "checksum": "eeb27d5f87220a7f1386652a841087b393e366649dc93f21ee79ef02aef64882",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -133,7 +133,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.8.tgz",
-      "checksum": "5fead40e29e9a6ffea962818bb84b8e149f2d4dce133bb2898ed354c9b02cdf8",
+      "checksum": "940b4eddaae72b83d275d7e0ca7270f8e1e94015945f3d485e06971505e3b5bf",
       "api": {
         "min": 2,
         "max": 2
@@ -153,7 +153,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.5.tgz",
-      "checksum": "341dac043b5f9c2f49860b249b959195e4a8dcae5edc576b779ea88a05d372f2",
+      "checksum": "335ccd07261c03490f164af2f4975a5bcdd71c6c649a45c7ac87a0e800e56fa0",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -169,7 +169,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.6.tgz",
-      "checksum": "07f02a7180271261eb3f91aa514136e68f414ff59be60ca54442e69bc0958460",
+      "checksum": "1ca8c70693484de2b4a0894f37e5ba9188f9ffc0c74882085cdb3ed4fefe05e1",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -185,7 +185,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.7.tgz",
-      "checksum": "5cfbb6e33f12792c249cbd528f110d38136e423ec98ba0537f095f4b1c86d8d8",
+      "checksum": "72717b2bb963ca711d2b35063ec62bf28a30bb2162d0bb21a820b59ccc303806",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -201,7 +201,7 @@
       },
       "version": "0.0.5",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.8.tgz",
-      "checksum": "c7c6d2fa7b2404452b123b81b90744c75d503cb72a106e12f53d8cda459754c3",
+      "checksum": "a2657d94af196f8cd30d17bd8d5ee3cd1c316f530b8e604bbbea30b7f5dc4841",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -17,7 +17,7 @@
       },
       "version": "0.0.4",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.5.tgz",
-      "checksum": "4774451f12f78e8d0668ad5dcefb742160ccda19a30e68ca56168cea3b7c4f08",
+      "checksum": "074e3dbd3a3b2ab3def8bdb449efb7f28d5902d2e7b0e6c658ecad9da5beea89",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -33,7 +33,7 @@
       },
       "version": "0.0.4",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.6.tgz",
-      "checksum": "d5869d1109fc08522fc110cba0eac3930c70b6dbe246753de086459ee2c62e8d",
+      "checksum": "ed2f29d6ce75cc6e9e7d7c51bdfd4a948e47078b13abf16f401c490285d52265",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -49,7 +49,7 @@
       },
       "version": "0.0.4",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.7.tgz",
-      "checksum": "d8e1ebcf4ce3999ac6fb7de50ce6f6fc4b64e328817ad423511bd1e69f710136",
+      "checksum": "35a925be2a9a96ddeeda2f96ea2198361f0fa0ef02e94227731732ae12c905c9",
       "gateway": {
         "min": "0.12.0",
         "max": "*"
@@ -65,7 +65,7 @@
       },
       "version": "0.0.4",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.8.tgz",
-      "checksum": "a9944c2fb865d3bb05e3490b9aab23bbf9c319ebc6e38c8b64095f9978ee06f0",
+      "checksum": "d5a866bb56c76092d648ebaa484fc664fcbfeae78d6ee5d586c340d5017611ff",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -15,8 +15,8 @@
           "3.5"
         ]
       },
-      "version": "0.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.5.tgz",
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.5.tgz",
       "checksum": "4774451f12f78e8d0668ad5dcefb742160ccda19a30e68ca56168cea3b7c4f08",
       "gateway": {
         "min": "0.12.0",
@@ -31,8 +31,8 @@
           "3.6"
         ]
       },
-      "version": "0.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.6.tgz",
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.6.tgz",
       "checksum": "d5869d1109fc08522fc110cba0eac3930c70b6dbe246753de086459ee2c62e8d",
       "gateway": {
         "min": "0.12.0",
@@ -47,8 +47,8 @@
           "3.7"
         ]
       },
-      "version": "0.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.7.tgz",
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.7.tgz",
       "checksum": "d8e1ebcf4ce3999ac6fb7de50ce6f6fc4b64e328817ad423511bd1e69f710136",
       "gateway": {
         "min": "0.12.0",
@@ -63,8 +63,8 @@
           "3.8"
         ]
       },
-      "version": "0.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.3-linux-arm-v3.8.tgz",
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.8.tgz",
       "checksum": "a9944c2fb865d3bb05e3490b9aab23bbf9c319ebc6e38c8b64095f9978ee06f0",
       "api": {
         "min": 2,

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -15,8 +15,8 @@
           "3.5"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.5.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.5.tgz",
       "checksum": "074e3dbd3a3b2ab3def8bdb449efb7f28d5902d2e7b0e6c658ecad9da5beea89",
       "gateway": {
         "min": "0.12.0",
@@ -31,8 +31,8 @@
           "3.6"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.6.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.6.tgz",
       "checksum": "ed2f29d6ce75cc6e9e7d7c51bdfd4a948e47078b13abf16f401c490285d52265",
       "gateway": {
         "min": "0.12.0",
@@ -47,8 +47,8 @@
           "3.7"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.7.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.7.tgz",
       "checksum": "35a925be2a9a96ddeeda2f96ea2198361f0fa0ef02e94227731732ae12c905c9",
       "gateway": {
         "min": "0.12.0",
@@ -63,8 +63,8 @@
           "3.8"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.8.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm-v3.8.tgz",
       "checksum": "d5a866bb56c76092d648ebaa484fc664fcbfeae78d6ee5d586c340d5017611ff",
       "api": {
         "min": 2,
@@ -83,8 +83,8 @@
           "3.5"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.5.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.5.tgz",
       "checksum": "494e37c3f19619c01b9a4792212230aea1efb6530136aded1f049771111e5cc6",
       "gateway": {
         "min": "0.12.0",
@@ -99,8 +99,8 @@
           "3.6"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.6.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.6.tgz",
       "checksum": "cdb0dd6867cafc9ddc5f3f34c1ed99f7a8facb6fea7a4793a681bbb3b3d58b9a",
       "gateway": {
         "min": "0.12.0",
@@ -115,8 +115,8 @@
           "3.7"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.7.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.7.tgz",
       "checksum": "5d1a386fda1525f87fbd4a92b4414bd775e8bee589109c4a250ee00ce4ea4a4e",
       "gateway": {
         "min": "0.12.0",
@@ -131,8 +131,8 @@
           "3.8"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.8.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-arm64-v3.8.tgz",
       "checksum": "5fead40e29e9a6ffea962818bb84b8e149f2d4dce133bb2898ed354c9b02cdf8",
       "api": {
         "min": 2,
@@ -151,8 +151,8 @@
           "3.5"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.5.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.5.tgz",
       "checksum": "341dac043b5f9c2f49860b249b959195e4a8dcae5edc576b779ea88a05d372f2",
       "gateway": {
         "min": "0.12.0",
@@ -167,8 +167,8 @@
           "3.6"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.6.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.6.tgz",
       "checksum": "07f02a7180271261eb3f91aa514136e68f414ff59be60ca54442e69bc0958460",
       "gateway": {
         "min": "0.12.0",
@@ -183,8 +183,8 @@
           "3.7"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.7.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.7.tgz",
       "checksum": "5cfbb6e33f12792c249cbd528f110d38136e423ec98ba0537f095f4b1c86d8d8",
       "gateway": {
         "min": "0.12.0",
@@ -199,8 +199,8 @@
           "3.8"
         ]
       },
-      "version": "0.0.4",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.8.tgz",
+      "version": "0.0.5",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.5-linux-x64-v3.8.tgz",
       "checksum": "c7c6d2fa7b2404452b123b81b90744c75d503cb72a106e12f53d8cda459754c3",
       "api": {
         "min": 2,

--- a/addons/awox-mesh-light-adapter.json
+++ b/addons/awox-mesh-light-adapter.json
@@ -1,6 +1,6 @@
 {
   "id": "awox-mesh-light-adapter",
-  "name": "AwoxMeshLight",
+  "name": "Awox Mesh Light",
   "description": "Awox mesh light device support",
   "author": "Philippe Coval",
   "homepage_url": "https://github.com/rzr/awox-mesh-light-webthing",
@@ -66,6 +66,142 @@
       "version": "0.0.4",
       "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm-v3.8.tgz",
       "checksum": "d5a866bb56c76092d648ebaa484fc664fcbfeae78d6ee5d586c340d5017611ff",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.5.tgz",
+      "checksum": "494e37c3f19619c01b9a4792212230aea1efb6530136aded1f049771111e5cc6",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.6.tgz",
+      "checksum": "cdb0dd6867cafc9ddc5f3f34c1ed99f7a8facb6fea7a4793a681bbb3b3d58b9a",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.7.tgz",
+      "checksum": "5d1a386fda1525f87fbd4a92b4414bd775e8bee589109c4a250ee00ce4ea4a4e",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-arm64-v3.8.tgz",
+      "checksum": "5fead40e29e9a6ffea962818bb84b8e149f2d4dce133bb2898ed354c9b02cdf8",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.5.tgz",
+      "checksum": "341dac043b5f9c2f49860b249b959195e4a8dcae5edc576b779ea88a05d372f2",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.6.tgz",
+      "checksum": "07f02a7180271261eb3f91aa514136e68f414ff59be60ca54442e69bc0958460",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.7.tgz",
+      "checksum": "5cfbb6e33f12792c249cbd528f110d38136e423ec98ba0537f095f4b1c86d8d8",
+      "gateway": {
+        "min": "0.12.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.4",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/awox-mesh-light-adapter-0.0.4-linux-x64-v3.8.tgz",
+      "checksum": "c7c6d2fa7b2404452b123b81b90744c75d503cb72a106e12f53d8cda459754c3",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
Base version to validate builder

Relate-to: https://github.com/rzr/awox-mesh-light-webthing/releases/tag/v0.0.2
Signed-off-by: Philippe Coval <rzr@users.sf.net>