### PR TITLE
Add Matrix Adapter

### DIFF
--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -1,0 +1,31 @@
+{
+  "id": "matrix-adapter",
+  "name": "Matrix",
+  "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
+  "author": "Christian Paul",
+  "homepage_url": "https://gitlab.com/webthings/matrix-adapter",
+  "license_url": "https://gitlab.com/webthings/matrix-adapter/-/blob/master/LICENSE",
+  "primary_type": "notifier",
+  "packages": [
+    {
+      "architecture": "any",
+      "language": {
+        "name": "nodejs",
+        "versions": [
+          "any"
+        ]
+      },
+      "version": "0.1.0",
+      "url": "https://gateway.pinata.cloud/ipfs/bafybeiaehbntjzvctq56lu6jnhbx4ejdld447eqt2imi6fpxwcuwugjlyy?filename=matrix-adapter-0.1.0.tgz",
+      "checksum": "dfb8b2e0923f0746ad6c887d6e9f86a7593731fe23184cd6ec7941e23a315c8f",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -1,6 +1,6 @@
 {
   "id": "matrix-adapter",
-  "name": "Matrix",
+  "name": "Matrix chat",
   "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
   "author": "Christian Paul",
   "homepage_url": "https://gitlab.com/webthings/matrix-adapter",

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -16,7 +16,7 @@
         ]
       },
       "version": "0.1.0",
-      "url": "https://gateway.pinata.cloud/ipfs/bafybeiaehbntjzvctq56lu6jnhbx4ejdld447eqt2imi6fpxwcuwugjlyy?filename=matrix-adapter-0.1.0.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/matrix-adapter-0.1.0.tgz",
       "checksum": "dfb8b2e0923f0746ad6c887d6e9f86a7593731fe23184cd6ec7941e23a315c8f",
       "api": {
         "min": 2,

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -3,7 +3,7 @@
   "name": "Matrix chat",
   "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
   "author": "Christian Paul",
-  "homepage_url": "https://gitlab.com/webthings/matrix-adapter",
+  "homepage_url": "https://gitlab.com/webthings/matrix-adapter#readme",
   "license_url": "https://gitlab.com/webthings/matrix-adapter/-/blob/master/LICENSE",
   "primary_type": "notifier",
   "packages": [


### PR DESCRIPTION
Allows to post custom or predefined unencrypted messages to one Matrix room.

![Screenshot_2020-06-19_13-49-41](https://user-images.githubusercontent.com/10872136/85130279-ecda6280-b234-11ea-9bc7-1be87a29e48c.png)

---

![Screenshot_2020-06-19 Riot IoT room](https://user-images.githubusercontent.com/10872136/85130418-3034d100-b235-11ea-8f57-0cbf4f0b7318.png)

---

![Screenshot_2020-06-19_13-52-55](https://user-images.githubusercontent.com/10872136/85130293-f4017080-b234-11ea-9559-1e6f1d1d4aec.png)

---

![Screenshot_2020-06-19_13-51-28](https://user-images.githubusercontent.com/10872136/85130305-fc59ab80-b234-11ea-802e-dd0d77356aaa.png)
