### PR TITLE
Matrix chat 0.2.1

### DIFF
--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -16,7 +16,7 @@
         ]
       },
       "version": "0.2.0",
-      "url": "https://gateway.pinata.cloud/ipfs/QmPczAsL2fbDy5kpUZiyWm2mhHVqPgstkFfQih3FVLc9Wc/matrix-adapter-0.2.0.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/matrix-adapter-0.2.0.tgz",
       "checksum": "3abfb2914af0b8e104e824ba36ff5c88d790f7333c4f66380d3dcaa31f8b6a60",
       "api": {
         "min": 2,

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -16,8 +16,8 @@
         ]
       },
       "version": "0.2.0",
-      "url": "https://gateway.pinata.cloud/ipfs/QmQ63ELv3R8cArvrHrcJxZuM6mbAEYojikJXfeduMcxxqn/matrix-adapter-0.2.0.tgz",
-      "checksum": "d8faa94d8a00e49858413409fca1baab98d2825314ab649232494a305ba5266f",
+      "url": "https://gateway.pinata.cloud/ipfs/QmayBLYY5YNj4Af7YSphDLAZFQHr1ocQ1i9fpVzN9G1i6a/matrix-adapter-0.2.0.tgz",
+      "checksum": "e7cf9ef68129a9e9f6bbfe6d84e357a8eb7a3c78c35dc7dd683b5590d681881f",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -3,7 +3,7 @@
   "name": "Matrix chat",
   "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
   "author": "Christian Paul",
-  "homepage_url": "https://gitlab.com/webthings/matrix-adapter#readme",
+  "homepage_url": "https://gitlab.com/webthings/matrix-adapter",
   "license_url": "https://gitlab.com/webthings/matrix-adapter/-/blob/master/LICENSE",
   "primary_type": "notifier",
   "packages": [
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.1.0",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/matrix-adapter-0.1.0.tgz",
-      "checksum": "dfb8b2e0923f0746ad6c887d6e9f86a7593731fe23184cd6ec7941e23a315c8f",
+      "version": "0.2.0",
+      "url": "https://gateway.pinata.cloud/ipfs/QmQ63ELv3R8cArvrHrcJxZuM6mbAEYojikJXfeduMcxxqn/matrix-adapter-0.2.0.tgz",
+      "checksum": "d8faa94d8a00e49858413409fca1baab98d2825314ab649232494a305ba5266f",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -16,7 +16,7 @@
         ]
       },
       "version": "0.2.1",
-      "url": "https://gateway.pinata.cloud/ipfs/QmVt8edw4mFCU4ahaiFQwc9uUjAKV9ixTvn6eYk8p5R5wm/matrix-adapter-0.2.1.tgz",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/matrix-adapter-0.2.1.tgz",
       "checksum": "b656eecf3d1f9eabb3e5d563ff1c3fa02f68c5dd217dcce0a35d590617d88ca5",
       "api": {
         "min": 2,

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -3,7 +3,7 @@
   "name": "Matrix chat",
   "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
   "author": "Christian Paul",
-  "homepage_url": "https://gitlab.com/webthings/matrix-adapter",
+  "homepage_url": "https://gitlab.com/webthings/matrix-adapter#readme",
   "license_url": "https://gitlab.com/webthings/matrix-adapter/-/blob/master/LICENSE",
   "primary_type": "notifier",
   "packages": [

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -16,8 +16,8 @@
         ]
       },
       "version": "0.2.0",
-      "url": "https://gateway.pinata.cloud/ipfs/QmayBLYY5YNj4Af7YSphDLAZFQHr1ocQ1i9fpVzN9G1i6a/matrix-adapter-0.2.0.tgz",
-      "checksum": "e7cf9ef68129a9e9f6bbfe6d84e357a8eb7a3c78c35dc7dd683b5590d681881f",
+      "url": "https://gateway.pinata.cloud/ipfs/QmPczAsL2fbDy5kpUZiyWm2mhHVqPgstkFfQih3FVLc9Wc/matrix-adapter-0.2.0.tgz",
+      "checksum": "3abfb2914af0b8e104e824ba36ff5c88d790f7333c4f66380d3dcaa31f8b6a60",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -3,7 +3,7 @@
   "name": "Matrix chat",
   "description": "Send unencrypted Matrix messages. For encryption use pantalaimon.",
   "author": "Christian Paul",
-  "homepage_url": "https://gitlab.com/webthings/matrix-adapter#readme",
+  "homepage_url": "https://gitlab.com/webthings/matrix-adapter",
   "license_url": "https://gitlab.com/webthings/matrix-adapter/-/blob/master/LICENSE",
   "primary_type": "notifier",
   "packages": [
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.2.0",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/matrix-adapter-0.2.0.tgz",
-      "checksum": "3abfb2914af0b8e104e824ba36ff5c88d790f7333c4f66380d3dcaa31f8b6a60",
+      "version": "0.2.1",
+      "url": "https://gateway.pinata.cloud/ipfs/QmVt8edw4mFCU4ahaiFQwc9uUjAKV9ixTvn6eYk8p5R5wm/matrix-adapter-0.2.1.tgz",
+      "checksum": "b656eecf3d1f9eabb3e5d563ff1c3fa02f68c5dd217dcce0a35d590617d88ca5",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
https://gitlab.com/webthings/matrix-adapter/-/blob/master/CHANGELOG.md#020-2020-06-26

* Posting now takes three properties: a message, a roomId and isNotice.
* Throw error when required config fields are missing.
* The room ID in the config became optional. The Notifier does not appear if no room ID got configured for it.
* A default roomID for messages can be specified.
* Added support for Notification Levels to the notifier.

---

![post-action](https://user-images.githubusercontent.com/10872136/85900018-5ba05880-b7ff-11ea-8622-ecadc992a70a.png)

---

![config](https://user-images.githubusercontent.com/10872136/85900029-61963980-b7ff-11ea-8301-4325d58ebdab.png)
