### PR TITLE
Internet radio 1.1.0

### DIFF
--- a/addons/internet-radio.json
+++ b/addons/internet-radio.json
@@ -19,8 +19,8 @@
         ]
       },
       "version": "1.0.1",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/internet-radio-1.0.1.tgz",
-      "checksum": "6a517ad9219ec70e88c247bc110a7387fd27f0b6ff995761ab7407ebcfd65903",
+      "url": "https://github.com/flatsiedatsie/internet-radio/releases/download/1.1.0/internet-radio-1.1.0.tgz",
+      "checksum": "95031a7c5a5cdb78193ebdfeff9935ebaeaa03bbe06c2de038341d800285a8cb",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/internet-radio.json
+++ b/addons/internet-radio.json
@@ -18,7 +18,7 @@
           "3.8"
         ]
       },
-      "version": "1.0.1",
+      "version": "1.1.0",
       "url": "https://github.com/flatsiedatsie/internet-radio/releases/download/1.1.0/internet-radio-1.1.0.tgz",
       "checksum": "95031a7c5a5cdb78193ebdfeff9935ebaeaa03bbe06c2de038341d800285a8cb",
       "api": {


### PR DESCRIPTION
- Volume is now set through ffplay instead of for the entire device. This makes it possible to set a relative volume. E.g. have the radio play at half the volume of Voco's output. The downside is that a volume change means ffplay is quickly restarted. The upside is that it can now offer volume control on USB audio cards that don't have a (simple) ALSA volume control option built in. This works around the inability to modify ALSA configuration settings at a more fundamental device level.
- Output device can now be set on the fly. This should also solve issues people were having with audio output, such as https://github.com/flatsiedatsie/internet-radio/issues/5