### PR TITLE
Voco 1.1.0

### DIFF
--- a/addons/voco.json
+++ b/addons/voco.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "1.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/voco-1.0.2.tgz",
-      "checksum": "78b1e3fd9c39b53825c5e75275a1edb476f6c684aead8a3f6ee5960ff7f69e18",
+      "version": "1.1.0",
+      "url": "https://candlesmarthome.com/assistant/voco-1.1.0.tgz",
+      "checksum": "0af6a3d16af32826d03e4c13264c5a678a3803bc044d9574156c053ca3011d26",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
- a new way of selecting audio output via a thing property. This should help solve issues users were having with all kinds of (USB) device configurations.
- audio volume can now be relative to other volumes
- change in how listening can be disabled. Instead of disabling the hotword detector, it now simply blocks analysis. This is more robust.
- small improvements to heuristics in cases where the meaning is not fully understood.
- can now only toggle one property state at once when a generic "turn device X on" command is used. If the device has multiple on-off properties, it picks the first one. In a future version this could have a capability preference.
- Code cleanup, removes some things, like being able to upload a custom assistant. Since Snips no longer exists, this is moot.