### PR TITLE
bugfix calendar - botched conversion to enum

### DIFF
--- a/addons/calendar.json
+++ b/addons/calendar.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.0.3",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/calendar-0.0.3.tgz",
-      "checksum": "732a0c166d04c8b2dc1fb5d622fe94fa1428fd60216017df7bb7a6082229757d",
+      "version": "0.0.5",
+      "url": "https://github.com/chas-iot/calendar/releases/download/v0.0.5/calendar-0.0.5.tgz",
+      "checksum": "05877fb6bc0f656e430ae7ea289169ff45cc0e7c109c03a4d9e925d5ee2bb753",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
please integrate, I missed the most key part during the conversion to enum - it never recognises a holiday