### PR TITLE
Square theme 1.0.0

### DIFF
--- a/addons/square-theme.json
+++ b/addons/square-theme.json
@@ -12,9 +12,9 @@
       "language": {
         "name": "none"
       },
-      "version": "0.0.5",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/square-theme-0.0.5.tgz",
-      "checksum": "dac32d68509009f0d5b34b3973ddd0ee284a8196015e0d740503aeaf693da6db",
+      "version": "1.0.0",
+      "url": "https://github.com/flatsiedatsie/square-theme/releases/download/1.0.0/square-theme-1.0.0.tgz",
+      "checksum": "ff6a6043f9137fb8dd2fbff496171fcbd66b0f1e54ae6ad6cad3ed1ea944fb83",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
Adds log filtering feature, where uses can select which logs on the logs overview page they want to actually see.

This filtering list is toggled with a button in the top right corner of the screen. This bring up the question/suggestion: how about reserving that corner for add-on use?