### PR TITLE
Initial release of P1 adapter

### DIFF
--- a/addons/p1-adapter
+++ b/addons/p1-adapter
@@ -1,0 +1,30 @@
+{
+  "id": "p1-adapter",
+  "name": "P1",
+  "description": "Connect to home energy meters that use the P1 standard",
+  "author": "CandleSmartHome.com",
+  "homepage_url": "https://github.com/createcandle/p1-adapter",
+  "license_url": "https://github.com/createcandle/p1-adapter/blob/master/LICENSE",
+  "primary_type": "adapter",
+  "packages": [
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7",
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://github.com/createcandle/p1-adapter/releases/download/0.0.1/p1-adapter-0.0.1.tgz",
+      "checksum": "2071f946e7b83a0e7e01fd7f115cf635fbd9099b2385ece6880c5f2352119c46",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/p1-adapter
+++ b/addons/p1-adapter
@@ -12,15 +12,252 @@
       "language": {
         "name": "python",
         "versions": [
-          "3.5",
-          "3.6",
-          "3.7",
+          "3.5"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm-v3.5.tgz",
+      "checksum": "515001692d0fd547cf2354913d0526eced60c6f219ab86be973b34162f5c2bdb",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm64-v3.5.tgz",
+      "checksum": "dd82373d9ce5935e67d06a7ddc3eec3b6cb6c5d6bd3f939cf0d50a2044333e07",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-x64-v3.5.tgz",
+      "checksum": "86ca1771c7ce1a861a519932e4e1eb549ef159e5ae92ce4764f9a0047fcc1f8c",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "darwin-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-darwin-x64-v3.5.tgz",
+      "checksum": "b54970529c96a4966d7e94bfb549e38aae83553d4099971dd515224387deae77",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm-v3.6.tgz",
+      "checksum": "dd6315007379362b79b3a28eb7bc5a06e863720559669d974e240dbf763bfacd",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm64-v3.6.tgz",
+      "checksum": "9732cc8266fc683b629aeed1a1686b01cba8f09217eadb1f24ce32277aa42cc9",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-x64-v3.6.tgz",
+      "checksum": "2db96dcf8eaff858c2874e6de754a124c65361f3e87269a8b6c85273bdc6e9d4",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "darwin-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.6"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-darwin-x64-v3.6.tgz",
+      "checksum": "8785adbccd9d5a0dbe2d4dcee31a550c42c8bc089ec76d1c3775cae6762e7279",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm-v3.7.tgz",
+      "checksum": "0beae005e54e008f6f141034fbb88ee1399a266709bd5e5c257f4167f702a379",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm64-v3.7.tgz",
+      "checksum": "6c345fbbbbe3c9480daeeae373392cf30162ee6ff914907013eb9aac46683b04",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-x64-v3.7.tgz",
+      "checksum": "b54cd89ad15d54079efad5ff8cc53c5955232c86d013e5ec35af5c61a7485a66",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "darwin-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.7"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-darwin-x64-v3.7.tgz",
+      "checksum": "cb62b1e8c593b0ef408828d5ff939f848f545b5aa6df318ae268083c9dc1f07c",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "python",
+        "versions": [
           "3.8"
         ]
       },
       "version": "0.0.1",
-      "url": "https://github.com/createcandle/p1-adapter/releases/download/0.0.1/p1-adapter-0.0.1.tgz",
-      "checksum": "2071f946e7b83a0e7e01fd7f115cf635fbd9099b2385ece6880c5f2352119c46",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm-v3.8.tgz",
+      "checksum": "f0535ad5ae049c776ed02829bded19da2abea3fed56c58ffbe3797785fe7a567",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-arm64-v3.8.tgz",
+      "checksum": "f10a39f0cc1b6b6c0ba09a72c5fe7ef9989d3cd9d96efa0c803bc9279dd2738e",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-linux-x64-v3.8.tgz",
+      "checksum": "bf22e65ff11742ce8698ba690b02d88e4f6209546ff5feae05cdd29c54e654f8",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "darwin-x64",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/p1-adapter-0.0.1-darwin-x64-v3.8.tgz",
+      "checksum": "f7babe951acf022741b9f13e5dd48438b1e67d6918066f57caa12834a5c7f5f7",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
Almost all Dutch and Belgian homes now have a 'smart' energy meter that follow the P1 standard. Without support for this, most Dutchies smarh home enthousiasts won't switch to the WebThings Gateway.

Funnily enough I don't own a P1 meter myself. I used an Arduino to emulate it.