### PR TITLE
Initial release of Highlights

### DIFF
--- a/addons/highlights.json
+++ b/addons/highlights.json
@@ -1,6 +1,6 @@
 {
   "id": "highlights",
-  "name": "HIghlights",
+  "name": "Highlights",
   "description": "Highlight any property on the things overview page",
   "author": "Flatsiedatsie",
   "homepage_url": "https://github.com/flatsiedatsie/highlights",

--- a/addons/highlights.json
+++ b/addons/highlights.json
@@ -1,0 +1,30 @@
+{
+  "id": "highlights",
+  "name": "HIghlights",
+  "description": "Highlight any property on the things overview page",
+  "author": "Flatsiedatsie",
+  "homepage_url": "https://github.com/flatsiedatsie/highlights",
+  "license_url": "https://raw.githubusercontent.com/flatsiedatsie/highlights/master/LICENSE",
+  "primary_type": "extension",
+  "packages": [
+    {
+      "architecture": "any",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7",
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://github.com/flatsiedatsie/highlights/releases/download/0.0.1/highlights-0.0.1.tgz",
+      "checksum": "ee07a268b7a74d1b4cabb18be055728e29f02b7c08c228c32980bf269eebf455",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}

--- a/addons/highlights.json
+++ b/addons/highlights.json
@@ -20,7 +20,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/highlights/releases/download/0.0.1/highlights-0.0.1.tgz",
-      "checksum": "ee07a268b7a74d1b4cabb18be055728e29f02b7c08c228c32980bf269eebf455",
+      "checksum": "c3ec68b4bcbc7fb6f191266b024dc371ef4e47fc48c60daa8499ee1167ec0e7e",
       "gateway": {
         "min": "0.10.0",
         "max": "*"

--- a/addons/highlights.json
+++ b/addons/highlights.json
@@ -20,7 +20,7 @@
       },
       "version": "0.0.1",
       "url": "https://github.com/flatsiedatsie/highlights/releases/download/0.0.1/highlights-0.0.1.tgz",
-      "checksum": "c3ec68b4bcbc7fb6f191266b024dc371ef4e47fc48c60daa8499ee1167ec0e7e",
+      "checksum": "e09d07b9fa906f630c56900adafd0c0afd22ef324db1aca90ced7dbe0c5e7adf",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
HIghlights allows users to highligh any property on the things overview page. This is a workaround for https://github.com/mozilla-iot/gateway/issues/1826