### PR TITLE
Network presence detection 1.1.0

### DIFF
--- a/addons/network-presence-detection-adapter.json
+++ b/addons/network-presence-detection-adapter.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "1.0.2",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/network-presence-detection-adapter-1.0.2.tgz",
-      "checksum": "e1d70efab65ed88ba3be4788ce011edbed719c5c6ae95dcb8738004fe6cd1967",
+      "version": "1.1.0",
+      "url": "https://github.com/flatsiedatsie/webthings-network-presence-detection/releases/download/1.1.0/network-presence-detection-adapter-1.1.0.tgz",
+      "checksum": "c95df7e323ce9f15440d356293545ad80f7a4d9e65885576db9e7215b06661a9",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
- shorter delay between continuous scans
- back up to 3 threads in the brute force scan
- Attempt to fix issue https://github.com/flatsiedatsie/webthings-network-presence-detection/issues/25
- small fix for issue https://github.com/flatsiedatsie/webthings-network-presence-detection/issues/30