### PR TITLE
calendar-v1.0.2

### DIFF
--- a/addons/calendar.json
+++ b/addons/calendar.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "1.0.0",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/calendar-1.0.0.tgz",
-      "checksum": "90b265a94f91c719b03b935b7e14d37f95fa1c4b71d3df0d0786561527a29adb",
+      "version": "1.0.2",
+      "url": "https://github.com/chas-iot/calendar/releases/download/v1.0.2/calendar-1.0.2.tgz",
+      "checksum": "27f9fab159ba08d81d3d45b3dbb1eb63f3bce03eef0195767e09c6eee0b6a3e9",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
- don't trigger error event on OK result
- correctly calculate reason, tag and source properties
- document new event