### PR TITLE
Voco 2.2.0

### DIFF
--- a/addons/voco.json
+++ b/addons/voco.json
@@ -3,7 +3,7 @@
   "name": "Voco",
   "description": "Privacy friendly voice control. Say 'Hey Snips' to start a voice command.",
   "author": "CandleSmartHome.com",
-  "homepage_url": "https://github.com/createcandle/voco",
+  "homepage_url": "https://www.candlesmarthome.com/voco-privacy-friendly-voice-control",
   "license_url": "https://raw.githubusercontent.com/createcandle/voco/master/LICENSE",
   "primary_type": "adapter",
   "packages": [

--- a/addons/voco.json
+++ b/addons/voco.json
@@ -18,9 +18,9 @@
           "3.8"
         ]
       },
-      "version": "2.0.1",
-      "url": "https://s3-us-west-2.amazonaws.com/mozilla-gateway-addons/voco-2.0.1.tgz",
-      "checksum": "a581e92f0d18e8f8a05a3b52247ca697eabeef28a4b2d958e42024fce02f7a79",
+      "version": "2.2.0",
+      "url": "https://www.candlesmarthome.com/assistant/voco-2.2.0.tgz",
+      "checksum": "d4c9c8ced0ad86bf9daaa4988bab70b25c7b62053929b522009634a9a06d91b2",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
- More rubust handling of satelite system, where sometimes a sytem (or the Voco addon) may not be up.
- Separation of hostname and site_id
- Small UI improvements (hostnames are exchanged and become visible)
- Option to do audio detection. Useful for home security, but also an interesting privacy case to try and handle.
- Option to say "hey Candle" as well
- Option to set initial system audio volume, to avoid issues of no audio output due to low volume.