### PR TITLE
Add denon adapter

### DIFF
--- a/addons/denon-adapter.json
+++ b/addons/denon-adapter.json
@@ -1,9 +1,9 @@
 {
     "id": "denon-adapter",
-    "name": "Denon HEOS",
-    "description": "Supports Denon AVRs and HEOS devices.",
+    "name": "Denon AVR & HEOS",
+    "description": "Adapter for Denon AVRs and possibly other HEOS devices",
     "author": "Martin Giger",
-    "homepage_url": "https://git.humanoids.be/freaktechnik/denon-adapter",
+    "homepage_url": "https://github.com/freaktechnik/denon-adapter",
     "license_url": "https://git.humanoids.be/freaktechnik/denon-adapter/raw/branch/main/LICENSE",
     "primary_type": "adapter",
     "packages": [


### PR DESCRIPTION
This adapter supports Denon AVRs and HEOS devices. It might also work for some Marantz AVRs (since that's the same company), but not sure.