### PR TITLE
Update for x10-cm11-adapter v0.6.5 for gateway v2.0.0+.

### DIFF
--- a/addons/x10-cm11-adapter.json
+++ b/addons/x10-cm11-adapter.json
@@ -211,7 +211,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm-v20.tgz",
       "checksum": "02b1b2dbfdb3c48b085d5d6332724dfdca83a64d0497b09e1d11c729cc93fc31",
       "gateway": {
-        "min": "2.0.0",
+        "min": "2.0.0-beta.1",
         "max": "*"
       }
     },
@@ -227,7 +227,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm64-v20.tgz",
       "checksum": "910344c6da7d7846e93c8ab41f90f31b692108ac462270c2899e6109a2803ace",
       "gateway": {
-        "min": "2.0.0",
+        "min": "2.0.0-beta.1",
         "max": "*"
       }
     },
@@ -243,7 +243,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-x64-v20.tgz",
       "checksum": "30b47652931b422f8ef1378b9b227d1a49710b930436c2440a6d271f1ccd3b82",
       "gateway": {
-        "min": "2.0.0",
+        "min": "2.0.0-beta.1",
         "max": "*"
       }
     }

--- a/addons/x10-cm11-adapter.json
+++ b/addons/x10-cm11-adapter.json
@@ -211,7 +211,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm-v20.tgz",
       "checksum": "02b1b2dbfdb3c48b085d5d6332724dfdca83a64d0497b09e1d11c729cc93fc31",
       "gateway": {
-        "min": "2.0.0-beta.1",
+        "min": "1.0.0",
         "max": "*"
       }
     },
@@ -227,7 +227,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm64-v20.tgz",
       "checksum": "910344c6da7d7846e93c8ab41f90f31b692108ac462270c2899e6109a2803ace",
       "gateway": {
-        "min": "2.0.0-beta.1",
+        "min": "1.0.0",
         "max": "*"
       }
     },
@@ -243,7 +243,7 @@
       "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-x64-v20.tgz",
       "checksum": "30b47652931b422f8ef1378b9b227d1a49710b930436c2440a6d271f1ccd3b82",
       "gateway": {
-        "min": "2.0.0-beta.1",
+        "min": "1.0.0",
         "max": "*"
       }
     }

--- a/addons/x10-cm11-adapter.json
+++ b/addons/x10-cm11-adapter.json
@@ -207,9 +207,9 @@
           "115"
         ]
       },
-      "version": "0.6.5",
-      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm-v20.tgz",
-      "checksum": "02b1b2dbfdb3c48b085d5d6332724dfdca83a64d0497b09e1d11c729cc93fc31",
+      "version": "0.6.6",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.6/x10-cm11-adapter-0.6.6-linux-arm-v20.tgz",
+      "checksum": "3d5cdc5a26bfcb109ee122d5bba45a7e3985e2e992a7f45fcca0cf055f6e8099",
       "gateway": {
         "min": "1.0.0",
         "max": "*"
@@ -223,9 +223,9 @@
           "115"
         ]
       },
-      "version": "0.6.5",
-      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm64-v20.tgz",
-      "checksum": "910344c6da7d7846e93c8ab41f90f31b692108ac462270c2899e6109a2803ace",
+      "version": "0.6.6",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.6/x10-cm11-adapter-0.6.6-linux-arm64-v20.tgz",
+      "checksum": "c605ba2df3a2009e9d49d982e6f9e6920af56eec3ac56be5e970db3d470727bb",
       "gateway": {
         "min": "1.0.0",
         "max": "*"
@@ -239,9 +239,9 @@
           "115"
         ]
       },
-      "version": "0.6.5",
-      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-x64-v20.tgz",
-      "checksum": "30b47652931b422f8ef1378b9b227d1a49710b930436c2440a6d271f1ccd3b82",
+      "version": "0.6.6",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.6/x10-cm11-adapter-0.6.6-linux-x64-v20.tgz",
+      "checksum": "9edadcff31941d65973f6eb1a69a87cf5992f8e7495cf2f88fc82881fb249996",
       "gateway": {
         "min": "1.0.0",
         "max": "*"

--- a/addons/x10-cm11-adapter.json
+++ b/addons/x10-cm11-adapter.json
@@ -198,6 +198,54 @@
         "min": "0.10.0",
         "max": "*"
       }
+    },
+    {
+      "architecture": "linux-arm",
+      "language": {
+        "name": "nodejs",
+        "versions": [
+          "115"
+        ]
+      },
+      "version": "0.6.5",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm-v20.tgz",
+      "checksum": "02b1b2dbfdb3c48b085d5d6332724dfdca83a64d0497b09e1d11c729cc93fc31",
+      "gateway": {
+        "min": "2.0.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-arm64",
+      "language": {
+        "name": "nodejs",
+        "versions": [
+          "115"
+        ]
+      },
+      "version": "0.6.5",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-arm64-v20.tgz",
+      "checksum": "910344c6da7d7846e93c8ab41f90f31b692108ac462270c2899e6109a2803ace",
+      "gateway": {
+        "min": "2.0.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "linux-x64",
+      "language": {
+        "name": "nodejs",
+        "versions": [
+          "115"
+        ]
+      },
+      "version": "0.6.5",
+      "url": "https://github.com/AlanDThiessen/x10-cm11-adapter/releases/download/v0.6.5/x10-cm11-adapter-0.6.5-linux-x64-v20.tgz",
+      "checksum": "30b47652931b422f8ef1378b9b227d1a49710b930436c2440a6d271f1ccd3b82",
+      "gateway": {
+        "min": "2.0.0",
+        "max": "*"
+      }
     }
   ]
 }


### PR DESCRIPTION
Update x10-cm11-adapter to version 0.6.5 with updated dependencies which support NodeJS version 20.
In particular, the cm11a-js node module now uses serialport 12.0.0.